### PR TITLE
fix ui 6.0-GA cann't connect oap 6.0

### DIFF
--- a/6/6.0.0-GA/ui/02-deployment.yml
+++ b/6/6.0.0-GA/ui/02-deployment.yml
@@ -45,3 +45,5 @@ spec:
         env:
         - name:  collector.ribbon.listOfServers
           value: oap:12800
+        - name:  collector.ribbon.ReadTimeout
+          value: "20000"


### PR DESCRIPTION
althought the ui has default timeout value,but i fount it not work,i try to explicit to set timeout value,well,it work