### PR TITLE
Add Values for init container in case of using private regestry;fix a whitespace/newline trimming bug

### DIFF
--- a/chart/skywalking/templates/_helpers.tpl
+++ b/chart/skywalking/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use for the oap cluster
 
 {{- define "skywalking.containers.wait-for-es" -}}
 - name: wait-for-elasticsearch
-  image: busybox:1.30
+  image: {{ .Values.initContainer.image }}:{{ .Values.initContainer.tag }}
   imagePullPolicy: IfNotPresent
 {{- if .Values.elasticsearch.enabled }}
   command: ['sh', '-c', 'for i in $(seq 1 60); do nc -z -w3 {{ .Values.elasticsearch.clusterName }}-{{ .Values.elasticsearch.nodeGroup }} {{ .Values.elasticsearch.httpPort }} && exit 0 || sleep 5; done; exit 1']

--- a/chart/skywalking/templates/ui-ingress.yaml
+++ b/chart/skywalking/templates/ui-ingress.yaml
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 {{- if .Values.ui.ingress.enabled }}
-{{- $serviceName := include "skywalking.ui.fullname" . -}}
-{{- $servicePort := .Values.ui.service.externalPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -32,6 +30,8 @@ metadata:
     {{- end }}
 spec:
   rules:
+    {{- $serviceName := include "skywalking.ui.fullname" . -}}
+    {{- $servicePort := .Values.ui.service.externalPort -}}
     {{- range .Values.ui.ingress.hosts }}
       {{- $url := splitList "/" . }}
     - host: {{ first $url }}

--- a/chart/skywalking/templates/ui-ingress.yaml
+++ b/chart/skywalking/templates/ui-ingress.yaml
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 {{- if .Values.ui.ingress.enabled }}
+{{- $serviceName := include "skywalking.ui.fullname" . }}
+{{- $servicePort := .Values.ui.service.externalPort }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -30,8 +32,6 @@ metadata:
     {{- end }}
 spec:
   rules:
-    {{- $serviceName := include "skywalking.ui.fullname" . -}}
-    {{- $servicePort := .Values.ui.service.externalPort -}}
     {{- range .Values.ui.ingress.hosts }}
       {{- $url := splitList "/" . }}
     - host: {{ first $url }}

--- a/chart/skywalking/values.yaml
+++ b/chart/skywalking/values.yaml
@@ -19,7 +19,9 @@
 
 serviceAccounts:
   oap:
-
+initContainer:
+  image: busybox
+  tag: '1.30'
 oap:
   name: oap
   # When 'dynamicConfigEnabled' set to true, enable oap dynamic configuration through k8s configmap，


### PR DESCRIPTION
I found that when ingress is enabled, the apiVersion line will go up to the comment in the generated `ui-ingress.yaml`.
![20200825151135.png](https://i.loli.net/2020/08/25/RPcfYgkQqEtVn6X.png)
this could be a helm bug.
the workaround is to move the variables down.