### PR TITLE
Add `services` resource role

### DIFF
--- a/chart/skywalking/templates/oap-clusterrole.yaml
+++ b/chart/skywalking/templates/oap-clusterrole.yaml
@@ -25,7 +25,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""]
-  resources: ["pods", "endpoints"]
+  resources: ["pods", "endpoints", "services"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["extensions"]
   resources: ["deployments", "replicasets"]


### PR DESCRIPTION
As we want to allow the users to specify the service name with something like `service.metadata.name` and `pod.metadata.labels.version`, we need access to `services` resource