### PR TITLE
fix istio adapter description

### DIFF
--- a/chart/skywalking/templates/istio-adapter/adapter.yaml
+++ b/chart/skywalking/templates/istio-adapter/adapter.yaml
@@ -20,7 +20,7 @@ kind: adapter
 metadata:
   name: skywalking-adapter
 spec:
-  description:
+  description: "skywaling-adapter"
   session_based: false
   templates:
     - metric


### PR DESCRIPTION
Hey，while I using this chart to install skywalking cluster，got error like this
`Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: unknown object type "nil" in adapter.spec.description`
so，i just edit `chart/templates/istio-adapter/adapter.yaml` and add description