### PR TITLE
Set up new helm test for 8.7.0-dev

### DIFF
--- a/.github/workflows/e2e.ci.yaml
+++ b/.github/workflows/e2e.ci.yaml
@@ -43,7 +43,7 @@ jobs:
           repository: apache/skywalking
           submodules: true
           path: main
-          ref: 5e4b16cbfc96f80bd86eb6a98ddcf60f0959c9b1
+          ref: 6228d450e1b0792dd9875ad68984c89c81ece742
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/e2e.ci.yaml
+++ b/.github/workflows/e2e.ci.yaml
@@ -111,7 +111,10 @@ jobs:
           export WEBAPP_HOST=127.0.0.1
           export WEBAPP_PORT=8080
 
-          cd main && ./mvnw --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false verify -Dit.test=org.apache.skywalking.e2e.mesh.ALSE2E
+          cd main
+          ./mvnw -q -f apm-application-toolkit -DskipTests -am install
+          SW_VERSION=$(./mvnw -q -DforceStdout -N org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version)
+          ./mvnw -q --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false -Dsw.version=${SW_VERSION} verify -Dit.test=org.apache.skywalking.e2e.mesh.ALSE2E
 
       - name: Logs
         if: ${{ failure() }}

--- a/.github/workflows/e2e.ci.yaml
+++ b/.github/workflows/e2e.ci.yaml
@@ -112,6 +112,7 @@ jobs:
           export WEBAPP_PORT=8080
 
           cd main
+          ./mvnw -q -DskipTests install
           ./mvnw -q -f apm-application-toolkit -DskipTests -am install
           SW_VERSION=$(./mvnw -q -DforceStdout -N org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version)
           ./mvnw -q --batch-mode -f test/e2e/pom.xml -am -DfailIfNoTests=false -Dsw.version=${SW_VERSION} verify -Dit.test=org.apache.skywalking.e2e.mesh.ALSE2E

--- a/.github/workflows/e2e.ci.yaml
+++ b/.github/workflows/e2e.ci.yaml
@@ -72,6 +72,7 @@ jobs:
                --set elasticsearch.replicas=1 \
                --set elasticsearch.minimumMasterNodes=1 \
                --set oap.env.SW_ENVOY_METRIC_ALS_HTTP_ANALYSIS=k8s-mesh \
+               --set oap.env.SW_ENVOY_METRIC_ALS_TCP_ANALYSIS=k8s-mesh \
                --set oap.env.K8S_SERVICE_NAME_RULE='e2e::${service.metadata.name}' \
                --set oap.envoy.als.enabled=true \
                --set oap.replicas=1 \

--- a/.github/workflows/e2e.ci.yaml
+++ b/.github/workflows/e2e.ci.yaml
@@ -89,7 +89,13 @@ jobs:
           kubectl get services -A -o wide
 
       - name: Deploy demo services
-        run: bash ${SCRIPTS_DIR}/demo.sh
+        run: |
+          bash ${SCRIPTS_DIR}/demo.sh
+          # Enable TCP services
+          kubectl apply -f https://raw.githubusercontent.com/istio/istio/$ISTIO_VERSION/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
+          kubectl apply -f https://raw.githubusercontent.com/istio/istio/$ISTIO_VERSION/samples/bookinfo/platform/kube/bookinfo-db.yaml
+          kubectl apply -f https://raw.githubusercontent.com/istio/istio/$ISTIO_VERSION/samples/bookinfo/networking/destination-rule-all.yaml
+          kubectl apply -f https://raw.githubusercontent.com/istio/istio/$ISTIO_VERSION/samples/bookinfo/networking/virtual-service-ratings-db.yaml
 
       - name: Cluster Info
         if: ${{ failure() }}

--- a/.github/workflows/e2e.ci.yaml
+++ b/.github/workflows/e2e.ci.yaml
@@ -72,6 +72,7 @@ jobs:
                --set elasticsearch.replicas=1 \
                --set elasticsearch.minimumMasterNodes=1 \
                --set oap.env.SW_ENVOY_METRIC_ALS_HTTP_ANALYSIS=k8s-mesh \
+               --set oap.env.K8S_SERVICE_NAME_RULE='e2e::${service.metadata.name}' \
                --set oap.envoy.als.enabled=true \
                --set oap.replicas=1 \
                --set ui.image.repository=skywalking/ui \


### PR DESCRIPTION
As we have a new webapp container, let's see the CI status. @kezhenxu94 I can see a compatibility test existing, it that test some old 8.x release? So, we should be good to support both webapp containers(zuul, and spring gateway), right?