### PR TITLE
Deploy helm chart snapshot to ghcr.io

### DIFF
--- a/.github/workflows/publish-helm.yaml
+++ b/.github/workflows/publish-helm.yaml
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish Snapshot Helm Chart
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  HUB: ghcr.io/apache/skywalking-kubernetes
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 20
+    name: Publish Snapshot Helm Chart
+    steps:
+      - uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ env.HUB }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy Helm Chart
+        run: |
+          sed -i "s/^version: .*/version: 0.0.0-${{ github.sha }}/" chart/skywalking/Chart.yaml
+          helm dep up chart/skywalking
+          helm package chart/skywalking
+          helm push skywalking-helm-*.tgz oci://${{ env.HUB }}


### PR DESCRIPTION
We can also deploy helm chart snapshot to ghcr.io so we can easily use for testing in other repo