### PR TITLE
Remove `.Values.oap.initEs` and replace with Helm Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ There are required values that you must set explicitly when deploying SkyWalking
 | ---- | ----------- | ------- |
 | `oap.image.tag` | the OAP docker image tag | `9.2.0` |
 | `oap.storageType` | the storage type of the OAP | `elasticsearch`, `postgresql`, etc. |
-| `oap.initEs`   | need to initial ElasticSearch  | `true`, `false` |
 | `ui.image.tag` | the UI docker image tag | `9.2.0` |
 
 You can set these required values via command line (e.g. `--set oap.image.tag=9.2.0 --set oap.storageType=elasticsearch`),

--- a/chart/skywalking/README.md
+++ b/chart/skywalking/README.md
@@ -8,7 +8,7 @@ This chart bootstraps a [Apache SkyWalking](https://skywalking.apache.org/) depl
 
 ## Prerequisites
 
- - Kubernetes 1.9.6+ 
+ - Kubernetes 1.9.6+
  - PV dynamic provisioning support on the underlying infrastructure (StorageClass)
  - Helm 3
 
@@ -45,7 +45,6 @@ The following table lists the configurable parameters of the Skywalking chart an
 | `imagePullSecrets`                                           | Image pull secrets                                                                               | `[]`                                 |
 | `oap.name`                                                   | OAP deployment name                                                                              | `oap`                                |
 | `oap.dynamicConfigEnabled`                                     | Enable oap dynamic configuration through k8s configmap                                           | `false`                              |
-| `oap.initEs`                                                 | Need to initial ElasticSearch                                                                    | `true`                              |
 | `oap.image.repository`                                       | OAP container image name                                                                         | `skywalking.docker.scarf.sh/apache/skywalking-oap-server`       |
 | `oap.image.tag`                                              | OAP container image tag                                                                          | `6.1.0`                              |
 | `oap.image.pullPolicy`                                       | OAP container image pull policy                                                                  | `IfNotPresent`                       |
@@ -218,7 +217,7 @@ ui:
 
 Envoy ALS(access log service) provides fully logs about RPC routed, including HTTP and TCP.
 
-If you want to open envoy ALS, you can do this by modifying values.yaml. 
+If you want to open envoy ALS, you can do this by modifying values.yaml.
 
 ```yaml
 oap:

--- a/chart/skywalking/templates/oap-init.job.yaml
+++ b/chart/skywalking/templates/oap-init.job.yaml
@@ -15,7 +15,6 @@
 
 # https://docs.sentry.io/server/installation/docker/#running-migrations
 
-{{- if and .Values.oap.initEs (contains "elasticsearch" .Values.oap.storageType) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -26,6 +25,9 @@ metadata:
     component: "{{ template "skywalking.fullname" . }}-job"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
 spec:
   template:
     metadata:
@@ -105,4 +107,3 @@ spec:
           configMap:
             name: {{ template "skywalking.fullname" . }}-oap-cm-override
         {{- end }}
-{{- end}}


### PR DESCRIPTION
`.Values.oap.initEs` was introduced in https://github.com/apache/skywalking-kubernetes/pull/88 to workaround the issue described in https://github.com/apache/skywalking/discussions/9290

With [Helm Chart Hooks](https://helm.sh/docs/topics/charts_hooks/) we can solve this problem better, this is how it works.

After all resources loaded into Kubernetes, Helm run the `oap-init` job, after the `oap-init` job successfully completed, Helm delete `oap-init`, next time when you do Helm upgrade, Helm will again deploy `oap-init` job and when it succeeds Helm will delete `oap-init` again, so there is no error when you redeploy/upgrade SkyWalking deployment.

JUST FYI @williamyao1982
