### PR TITLE
Update Elasticsearch chart dependency to 8.5.1

### DIFF
--- a/chart/skywalking/Chart.yaml
+++ b/chart/skywalking/Chart.yaml
@@ -31,7 +31,7 @@ maintainers:
 
 dependencies:
   - name: elasticsearch
-    version: ~7.5.1
+    version: ~8.5.1
     repository: https://helm.elastic.co/
     condition: elasticsearch.enabled
   - name: postgresql


### PR DESCRIPTION
The old version uses an outdated apiVersion for kind: PodDisruptionBudget, which breaks this chart for Kubernetes 1.21 and ongoing.

The following error emerges when using the old Elastic Helm chart: 

```
Error: UPGRADE FAILED: resource mapping not found for name: "elasticsearch-master-pdb" namespace: "" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
```

As you can see, the newer version of the Elastic Helm chart uses some logic to pass the correct apiVersion: https://github.com/elastic/helm-charts/blob/v8.5.1/elasticsearch/templates/poddisruptionbudget.yaml

Kind regards
Franz