### PR TITLE
Adding the `configmap` into cluster role for oap init mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Release Notes.
 - Add helm chart for swck v0.7.0.
 - Add `pprof` port export in satellite.
 - Trunc the resource name in swck's helm chart to no more than 63 characters.
+- Adding the `configmap` into cluster role for oap init mode.
 
 4.4.0
 ------------------

--- a/chart/skywalking/templates/oap-clusterrole.yaml
+++ b/chart/skywalking/templates/oap-clusterrole.yaml
@@ -25,7 +25,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""]
-  resources: ["pods", "pods/log", "endpoints", "services", "nodes", "namespaces"]
+  resources: ["pods", "pods/log", "endpoints", "services", "nodes", "namespaces","configmaps"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["extensions"]
   resources: ["deployments", "replicasets"]


### PR DESCRIPTION
After https://github.com/apache/skywalking/pull/10917, I'm trying to use skywalking showcase to deploy the latest OAP, then I see the error when starting the oap-init which shows it needs the config map roles. So I add the configmaps into the cluster role. 
![image](https://github.com/apache/skywalking-kubernetes/assets/3417650/38a6a4df-6a8f-411b-bc34-5953c45e6dec)
