### PR TITLE
Add `extraPodLabels` to `oapInit` so Job can have additional labels

### DIFF
--- a/chart/skywalking/templates/oap-init.job.yaml
+++ b/chart/skywalking/templates/oap-init.job.yaml
@@ -25,8 +25,6 @@ metadata:
     component: "{{ template "skywalking.fullname" . }}-job"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.oapInit.extraLabels }}
-{{ toYaml .Values.oapInit.extraLabels | indent 4 }}
 {{- end }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
@@ -39,6 +37,9 @@ spec:
         app: {{ template "skywalking.name" . }}
         component: "{{ template "skywalking.fullname" . }}-job"
         release: {{ .Release.Name }}
+{{- if .Values.oapInit.extraPodLabels }}
+{{ toYaml .Values.oapInit.extraPodLabels | indent 8 }}
+
     spec:
       serviceAccountName: {{ template "skywalking.serviceAccountName.oap" . }}
       {{- with .Values.oap.securityContext }}

--- a/chart/skywalking/templates/oap-init.job.yaml
+++ b/chart/skywalking/templates/oap-init.job.yaml
@@ -25,7 +25,6 @@ metadata:
     component: "{{ template "skywalking.fullname" . }}-job"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-weight": "1"
@@ -39,7 +38,7 @@ spec:
         release: {{ .Release.Name }}
 {{- if .Values.oapInit.extraPodLabels }}
 {{ toYaml .Values.oapInit.extraPodLabels | indent 8 }}
-
+{{- end }}
     spec:
       serviceAccountName: {{ template "skywalking.serviceAccountName.oap" . }}
       {{- with .Values.oap.securityContext }}

--- a/chart/skywalking/templates/oap-init.job.yaml
+++ b/chart/skywalking/templates/oap-init.job.yaml
@@ -25,8 +25,8 @@ metadata:
     component: "{{ template "skywalking.fullname" . }}-job"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.oapInit.additionalLabels }}
-{{ toYaml .Values.oapInit.additionalLabels | indent 4 }}
+{{- if .Values.oapInit.extraLabels }}
+{{ toYaml .Values.oapInit.extraLabels | indent 4 }}
 {{- end }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback

--- a/chart/skywalking/templates/oap-init.job.yaml
+++ b/chart/skywalking/templates/oap-init.job.yaml
@@ -25,6 +25,9 @@ metadata:
     component: "{{ template "skywalking.fullname" . }}-job"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.oapInit.additionalLabels }}
+{{ toYaml .Values.oapInit.additionalLabels | indent 4 }}
+{{- end }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-weight": "1"


### PR DESCRIPTION
Issue:  `oap-init` job is unable to be completed when `istio-injection: true` is set on a namespace.  The container specific to the job works, but the job does not mark as complete due to the lack of `istio-init` completing.

Solution: Add additional labels to `spec.template.metadata.labels` (e.g. `sidecar.istio.io/inject: false`), to the job-generated pod, which enables the job to complete properly when Istio is installed..



Unblock oap-init job from being blocked when Istio injection is enabled for a namespace