### PR TITLE
Remove eck-operator hard dependency for non-ES storage backends

### DIFF
--- a/.github/workflows/e2e.ci.yaml
+++ b/.github/workflows/e2e.ci.yaml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Login to ghcr
-        uses: docker/login-action@v1
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/publish-helm.yaml
+++ b/.github/workflows/publish-helm.yaml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Log in to the Container registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.HUB }}
           username: ${{ github.actor }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ test/e2e/              # E2E test configs (skywalking-infra-e2e format)
 ## Chart Dependencies
 
 Defined in `chart/skywalking/Chart.yaml`:
-- **eck-operator** (3.3.1) — ECK operator, condition: `eckOperator.enabled`
+- **eck-operator** (3.3.1) — ECK operator, condition: `elasticsearch.enabled`
 - **eck-elasticsearch** (0.18.1, alias: `elasticsearch`) — ECK-managed ES, condition: `elasticsearch.enabled`
 - **postgresql** (12.1.2) — Bitnami PostgreSQL, condition: `postgresql.enabled`
 - **skywalking-banyandb-helm** (alias: `banyandb`) — BanyanDB, condition: `banyandb.enabled`
@@ -74,8 +74,7 @@ helm template test chart/skywalking \
   --set oap.image.tag=10.3.0 \
   --set oap.storageType=elasticsearch \
   --set ui.image.tag=10.3.0 \
-  --set elasticsearch.enabled=false \
-  --set eckOperator.enabled=false
+  --set elasticsearch.enabled=false
 
 # Package chart
 make package

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,11 @@ When modifying chart configuration, update all of:
 4. `chart/skywalking/values-my-es.yaml` — external ES example (if ES-related)
 5. `test/e2e/values.yaml` — test overrides (if defaults change)
 
+## GitHub Actions Allow List
+
+Apache enforces an allow list for third-party GitHub Actions. All third-party actions must be pinned to an approved SHA from:
+https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml
+
 ## Git Workflow
 
 - **Do not push directly to master.** Always create a feature branch and open a PR.

--- a/README.md
+++ b/README.md
@@ -135,14 +135,23 @@ here are some examples.
 helm install "${SKYWALKING_RELEASE_NAME}" ${REPO}/skywalking -n "${SKYWALKING_RELEASE_NAMESPACE}" \
   --set oap.image.tag=10.3.0 \
   --set oap.storageType=elasticsearch \
-  --set ui.image.tag=10.3.0
+  --set ui.image.tag=10.3.0 \
+  --set eck-operator.installCRDs=false
 ```
 
-Elasticsearch is now deployed via [ECK (Elastic Cloud on Kubernetes)](https://github.com/elastic/cloud-on-k8s).
-By default, the chart deploys the ECK operator and an Elasticsearch 8.18.8 cluster.
-The ECK operator is automatically installed when `elasticsearch.enabled=true` and skipped otherwise.
+Elasticsearch is deployed via [ECK (Elastic Cloud on Kubernetes)](https://github.com/elastic/cloud-on-k8s).
+When `elasticsearch.enabled=true` (the default), the chart deploys both the ECK operator and an Elasticsearch 8.18.8 cluster.
+Because Elasticsearch CRDs must exist before the chart can be installed, you need to install them first:
 
-To use an existing external Elasticsearch instead, disable the embedded deployment:
+```shell
+helm dep up chart/skywalking
+tar xzf chart/skywalking/charts/eck-operator-3.3.1.tgz -C /tmp eck-operator/charts/eck-operator-crds
+helm install eck-crds /tmp/eck-operator/charts/eck-operator-crds -n "${SKYWALKING_RELEASE_NAMESPACE}" --create-namespace
+```
+
+Then install the chart with `--set eck-operator.installCRDs=false` to avoid duplicating the CRDs.
+
+To use an existing external Elasticsearch instead, disable the embedded deployment (no CRD pre-install needed):
 
 ```yaml
 elasticsearch:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ helm install "${SKYWALKING_RELEASE_NAME}" \
   --set oap.image.tag=10.3.0 \
   --set oap.storageType=banyandb \
   --set ui.image.tag=10.3.0 \
-  --set eckOperator.enabled=false \
   --set elasticsearch.enabled=false \
   --set banyandb.enabled=true \
   --set banyandb.image.tag=0.9.0
@@ -141,14 +140,11 @@ helm install "${SKYWALKING_RELEASE_NAME}" ${REPO}/skywalking -n "${SKYWALKING_RE
 
 Elasticsearch is now deployed via [ECK (Elastic Cloud on Kubernetes)](https://github.com/elastic/cloud-on-k8s).
 By default, the chart deploys the ECK operator and an Elasticsearch 8.18.8 cluster.
-If you already have the ECK operator installed, set `eckOperator.enabled=false`.
+The ECK operator is automatically installed when `elasticsearch.enabled=true` and skipped otherwise.
 
 To use an existing external Elasticsearch instead, disable the embedded deployment:
 
 ```yaml
-eckOperator:
-  enabled: false
-
 elasticsearch:
   enabled: false
   config:

--- a/chart/skywalking/Chart.yaml
+++ b/chart/skywalking/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
 - name: eck-operator
   version: 3.3.1
   repository: https://helm.elastic.co/
-  condition: eckOperator.enabled
+  condition: elasticsearch.enabled
 - name: eck-elasticsearch
   alias: elasticsearch
   version: 0.18.1

--- a/chart/skywalking/README.md
+++ b/chart/skywalking/README.md
@@ -118,14 +118,13 @@ The following table lists the configurable parameters of the Skywalking chart an
 ### Elasticsearch (ECK)
 
 Elasticsearch is deployed via [ECK (Elastic Cloud on Kubernetes)](https://github.com/elastic/cloud-on-k8s).
-The chart includes the ECK operator and an `eck-elasticsearch` subchart. Set `eckOperator.enabled=false` if the ECK operator is already installed in your cluster.
+The chart includes the ECK operator and an `eck-elasticsearch` subchart. The ECK operator is automatically installed when `elasticsearch.enabled=true` and skipped otherwise.
 
 #### Top-level parameters
 
 | Parameter | Description | Default |
 |---|---|---|
-| `eckOperator.enabled` | Deploy the ECK operator | `true` |
-| `elasticsearch.enabled` | Deploy an ECK-managed Elasticsearch cluster | `true` |
+| `elasticsearch.enabled` | Deploy the ECK operator and an ECK-managed Elasticsearch cluster | `true` |
 | `elasticsearch.version` | Elasticsearch version to deploy | `8.18.8` |
 | `elasticsearch.fullnameOverride` | Override the Elasticsearch resource name. The ECK service will be `{name}-es-http` | `""` |
 | `elasticsearch.labels` | Labels applied to the Elasticsearch resource | `{}` |

--- a/chart/skywalking/README.md
+++ b/chart/skywalking/README.md
@@ -119,6 +119,7 @@ The following table lists the configurable parameters of the Skywalking chart an
 
 Elasticsearch is deployed via [ECK (Elastic Cloud on Kubernetes)](https://github.com/elastic/cloud-on-k8s).
 The chart includes the ECK operator and an `eck-elasticsearch` subchart. The ECK operator is automatically installed when `elasticsearch.enabled=true` and skipped otherwise.
+If the ECK operator is already installed in your cluster, you can skip its duplicate deployment by setting `eck-operator.replicaCount=0` and `eck-operator.installCRDs=false`.
 
 #### Top-level parameters
 

--- a/chart/skywalking/README.md
+++ b/chart/skywalking/README.md
@@ -118,8 +118,8 @@ The following table lists the configurable parameters of the Skywalking chart an
 ### Elasticsearch (ECK)
 
 Elasticsearch is deployed via [ECK (Elastic Cloud on Kubernetes)](https://github.com/elastic/cloud-on-k8s).
-The chart includes the ECK operator and an `eck-elasticsearch` subchart. The ECK operator is automatically installed when `elasticsearch.enabled=true` and skipped otherwise.
-If the ECK operator is already installed in your cluster, you can skip its duplicate deployment by setting `eck-operator.replicaCount=0` and `eck-operator.installCRDs=false`.
+The chart includes the ECK operator and an `eck-elasticsearch` subchart, both controlled by `elasticsearch.enabled`.
+Because Elasticsearch CRDs must exist before the ES custom resource can be created, the ECK operator CRDs need to be installed separately before deploying the chart. See the main [README](../../README.md) for installation steps.
 
 #### Top-level parameters
 

--- a/chart/skywalking/values-my-es.yaml
+++ b/chart/skywalking/values-my-es.yaml
@@ -26,9 +26,6 @@ ui:
   image:
     tag: 10.0.0
 
-eckOperator:
-  enabled: false
-
 elasticsearch:
   enabled: false
   config:               # For users of an existing elasticsearch cluster, takes effect when `elasticsearch.enabled` is false

--- a/chart/skywalking/values.yaml
+++ b/chart/skywalking/values.yaml
@@ -194,12 +194,8 @@ oapInit:
   extraPodLabels: {}
   # sidecar.istio.io/inject: false
 
-# ECK Operator settings
-# Set eckOperator.enabled to false if the ECK operator is already installed in your cluster
-eckOperator:
-  enabled: true
-
 # Elasticsearch managed by ECK (eck-elasticsearch chart)
+# When enabled, the ECK operator is also installed as a dependency.
 # ref: https://github.com/elastic/cloud-on-k8s
 elasticsearch:
   enabled: true

--- a/test/e2e/e2e-elasticsearch.yaml
+++ b/test/e2e/e2e-elasticsearch.yaml
@@ -40,17 +40,12 @@ setup:
         kubectl label namespace default istio-injection=enabled
     - name: Install helm
       command: bash test/e2e/setup-e2e-shell/install.sh helm
-    - name: Install ECK operator
-      command: |
-        helm dep up chart/skywalking
-        helm -n istio-system install eck-operator chart/skywalking/charts/eck-operator-3.3.1.tgz \
-                       --create-namespace
-        kubectl -n istio-system rollout status --watch --timeout=120s statefulset/elastic-operator
     - name: Install SkyWalking
       command: |
+        helm dep up chart/skywalking
         helm -n istio-system install skywalking chart/skywalking \
+                       --create-namespace \
                        --set fullnameOverride=skywalking \
-                       --set eckOperator.enabled=false \
                        --set oap.env.SW_ENVOY_METRIC_ALS_HTTP_ANALYSIS=k8s-mesh \
                        --set oap.env.SW_ENVOY_METRIC_ALS_TCP_ANALYSIS=k8s-mesh \
                        --set oap.env.K8S_SERVICE_NAME_RULE='e2e::${service.metadata.name}' \

--- a/test/e2e/e2e-elasticsearch.yaml
+++ b/test/e2e/e2e-elasticsearch.yaml
@@ -40,7 +40,7 @@ setup:
         kubectl label namespace default istio-injection=enabled
     - name: Install helm
       command: bash test/e2e/setup-e2e-shell/install.sh helm
-    - name: Install ECK CRDs
+    - name: Install ECK operator
       command: |
         helm dep up chart/skywalking
         tar xzf chart/skywalking/charts/eck-operator-3.3.1.tgz -C /tmp eck-operator/charts/eck-operator-crds

--- a/test/e2e/e2e-elasticsearch.yaml
+++ b/test/e2e/e2e-elasticsearch.yaml
@@ -40,12 +40,18 @@ setup:
         kubectl label namespace default istio-injection=enabled
     - name: Install helm
       command: bash test/e2e/setup-e2e-shell/install.sh helm
-    - name: Install SkyWalking
+    - name: Install ECK operator
       command: |
         helm dep up chart/skywalking
+        helm -n istio-system install eck-operator chart/skywalking/charts/eck-operator-3.3.1.tgz \
+                       --create-namespace
+        kubectl -n istio-system rollout status --watch --timeout=120s statefulset/elastic-operator
+    - name: Install SkyWalking
+      command: |
         helm -n istio-system install skywalking chart/skywalking \
-                       --create-namespace \
                        --set fullnameOverride=skywalking \
+                       --set eck-operator.replicaCount=0 \
+                       --set eck-operator.installCRDs=false \
                        --set oap.env.SW_ENVOY_METRIC_ALS_HTTP_ANALYSIS=k8s-mesh \
                        --set oap.env.SW_ENVOY_METRIC_ALS_TCP_ANALYSIS=k8s-mesh \
                        --set oap.env.K8S_SERVICE_NAME_RULE='e2e::${service.metadata.name}' \

--- a/test/e2e/e2e-elasticsearch.yaml
+++ b/test/e2e/e2e-elasticsearch.yaml
@@ -40,17 +40,16 @@ setup:
         kubectl label namespace default istio-injection=enabled
     - name: Install helm
       command: bash test/e2e/setup-e2e-shell/install.sh helm
-    - name: Install ECK operator
+    - name: Install ECK CRDs
       command: |
         helm dep up chart/skywalking
-        helm -n istio-system install eck-operator chart/skywalking/charts/eck-operator-3.3.1.tgz \
+        tar xzf chart/skywalking/charts/eck-operator-3.3.1.tgz -C /tmp eck-operator/charts/eck-operator-crds
+        helm -n istio-system install eck-crds /tmp/eck-operator/charts/eck-operator-crds \
                        --create-namespace
-        kubectl -n istio-system rollout status --watch --timeout=120s statefulset/elastic-operator
     - name: Install SkyWalking
       command: |
         helm -n istio-system install skywalking chart/skywalking \
                        --set fullnameOverride=skywalking \
-                       --set eck-operator.replicaCount=0 \
                        --set eck-operator.installCRDs=false \
                        --set oap.env.SW_ENVOY_METRIC_ALS_HTTP_ANALYSIS=k8s-mesh \
                        --set oap.env.SW_ENVOY_METRIC_ALS_TCP_ANALYSIS=k8s-mesh \


### PR DESCRIPTION
## Summary
- Removed the standalone `eckOperator.enabled` flag. The eck-operator chart dependency now shares the `elasticsearch.enabled` condition, so it is only deployed when Elasticsearch is in use.
- BanyanDB and PostgreSQL users no longer need to explicitly disable the ECK operator — setting `elasticsearch.enabled=false` is sufficient.
- Pinned `docker/login-action` to the Apache-approved SHA (v4.0.0) in CI workflows.
- Updated the ES e2e test to pre-install ECK CRDs separately (required because Helm validates CRs against the API server before applying).

## Test plan
- [ ] `helm template` with `elasticsearch.enabled=false` produces zero eck-operator resources
- [ ] `helm template` with `elasticsearch.enabled=true` includes eck-operator resources
- [ ] ES e2e test passes with CRD pre-install + `eck-operator.installCRDs=false`
- [ ] BanyanDB e2e tests pass without any ECK references