### PR TITLE
Bump up banyandb helm version to 0.7.0-rc1

### DIFF
--- a/chart/skywalking/Chart.yaml
+++ b/chart/skywalking/Chart.yaml
@@ -45,6 +45,6 @@ dependencies:
   condition: postgresql.enabled
 - name: skywalking-banyandb-helm
   alias: banyandb
-  version: 0.7.0-rc0
+  version: 0.7.0-rc1
   repository: oci://registry-1.docker.io/apache
   condition: banyandb.enabled

--- a/test/e2e/env
+++ b/test/e2e/env
@@ -28,6 +28,6 @@ SWCK_OPERATOR_REPO=docker.io/apache/skywalking-swck
 SWCK_OPERATOR_TAG=0.10.0
 SATELLITE_TAG=v35bfaff6352b4dc351a706772796a1f79b651c14
 SATELLITE_REPO=ghcr.io/apache/skywalking-satellite/skywalking-satellite
-BANYANDB_TAG=2c9946197a9df91dd02cffdeb880aa00a12f837d
+BANYANDB_TAG=36921708b3bd3e0cd0ca37db9761fadf685c99a1
 BANYANDB_REPO=ghcr.io/apache/skywalking-banyandb
 SW_CTL_COMMIT=9a1beab08413ce415a00a8547a238a14691c5655


### PR DESCRIPTION
## Summary

Point the banyandb subchart at the just-published **0.7.0-rc1** chart (adds the optional canopy web console via `canopy.enabled`; `image.tag` is now required with no default — already satisfied here via `banyandb.image.tag`).

- `chart/skywalking/Chart.yaml`: 0.7.0-rc0 → 0.7.0-rc1
- `test/e2e/env`: `BANYANDB_TAG` → 36921708b3bd3e0cd0ca37db9761fadf685c99a1 (current main; -testing and -canopy images published)

## Test plan

- `helm dep up chart/skywalking` resolves the subchart to the published 0.7.0-rc1 digest (sha256:627f14d8…) — the exact artifact pushed by `make publish`.
- e2e scenarios unchanged; they pass `banyandb.image.tag` explicitly.